### PR TITLE
Update to DOM efficiency and baseline sections

### DIFF
--- a/dom.tex
+++ b/dom.tex
@@ -529,7 +529,21 @@ and the waveform pulse unfolding used in data processing.
  \label{fig:domcal_hv_settings}
 \end{figure}
 
-\subsubsection{Flasher Calibrations}
+\subsection{\label{sec:domeff} DOM Optical Efficiency}
+
+The UV photon detection efficiency in air is measured in the lab using a
+pulsed 337~nm laser beam through a nitrogen gas chamber~\cite{ICECUBE:PMT}. Photons
+which are Rayleigh scattered 90$^{\circ}$ from the beam illuminate the PMT,
+which is rotated at various angles to measure different sections of
+the photocathode surface. The quantum efficiency at the center of the
+photocathode, where collection efficiency is nearly 100\%, was found
+to be 20\% at 337~nm, which agrees well with the Hamamatsu
+specification of 25\% at 390~nm. Lab measurements of the absolute efficiency of the DOM efficiency in water are ongoing~\cite{ICECUBE:DOMEFF}. The absolute calibration was performed on a small subset of IceCube DOMs. The relative efficiency of all DOMs was measured in the FAT process using a 405~nm pulsed laser and a system of fibers and diffusers to illuminate the DOM evenly within 50$^{\circ}$ of the optical axis; the DOM was not rotated for this measurement. The efficiency of each DOM was measured relative to a 2~inch reference PMT. The PMTs in most DeepCore DOMs are high quantum efficiency, nominally 40\% higher than PMTs in standard IceCube DOMs. FAT measurements found that the high quantum efficiency PMTs were 39\% more efficient than standard IceCube PMTs~\cite{ICECUBE:DC}.
+
+Laboratory measurements of PMT efficiency are supplemented with in situ measurements using Cherenkov light from muons in the ice. Low energy muons (median energy 82~GeV) with inclination angles between 45$^{\circ}$ and 70$^{\circ}$ have well understood light emission and illuminate the downward-facing PMTs in the ice as directly as possible. The deposited charge from these muons is compared to simulation to adjust the effective efficiency of the PMTs in ice~\cite{IC3:ereco}. DOM occupancy from muons was used to measure the relative efficiency of the HQE and standard DOMs in ice, which was found to be 35\%~\cite{ICECUBE:DC}. The dark noise rates in HQE DOMs are 33\% higher than in standard DOMs.
+
+
+%\subsubsection{Flasher Calibrations}
 
 \subsection{Performance and Reliability}
 
@@ -612,28 +626,49 @@ minimize the number of DOM power cycles.
 
 \subsubsection{Baseline Stability}
 
-The digitizer pedestals are set to about 10\% of the maximum value in
-order to capture signals that go below the baseline. The baseline
-refers to the average value of this offset, whereas the pedestal
-pattern refers to the bin-to-bin variation of the pedestal
-setting. The pedestal pattern is subtracted off inside the DOM, but
-the baseline is subtracted during data processing at the
-surface. Since 2012, the average
-baseline value is set by the DAQ configuration in order to ensure
-stability. The average value differs for each digitizer channel in
-each DOM, ranging from XX to XX ADC counts. The pedestal pattern is computed at the beginning of each
+An ATWD waveform consists of readouts from 128 independent digitizers,
+while an FADC waveform consists of successive outputs of a 6-stage
+pipelined digitizer (3 bins for SLC launches and 256 for HLC
+launches). Two calibration constants are needed to turn each of these
+raw digitizer readout values (an integer number of ADC counts) into a
+voltage, from which the deposited charge is calculated. The deposited
+charge is the basis for all energy measurements in IceCube. The
+calibration constants needed are 1) the pedestal, the value the digitizer reads when the input voltage is zero, and
+2) the gain, the input voltage required to increase increase the readout value by one count. 
+
+Since each bin of each ATWD channel is read from an independent
+digitizer, it is important to distinguish between the pedestals of
+individual bins and the common pedestal of the entire waveform. The
+baseline is the mean of the pedestals of each bin in a waveform. For
+the FADC, this is the same as the pedestal. The pedestal pattern is
+the deviation of each bin's pedestal from the common baseline. For the
+FADC, this is identically zero. Since 2008, the DOM has subtracted the
+pedestal pattern from
+the ATWD waveform before sending it to the surface. The pedestal pattern is computed at the beginning of each
 run by comparing 25 averaged pedestals. The autocorrelation coefficent
 between the pairs of averaged pedestals is computed to detect light
 contamination in the pedestals, and the shift between the baseline of
 the pairs is calculated to determine that the baseline is stable. This
 procedure ensures that fewer than 1 DOM in 1000 runs will contain a
-contaminated baseline.
+contaminated baseline. Thereafter, both ATWD
+and FADC waveforms can be calibrated by first subtracting the common
+baseline from each bin, then multiplying by the gain. Correct
+measurement of the common baseline is critical to correct charge
+measurement and energy reconstruction.
 
-The baselines for each digitizer channel in each DOM are monitored with
-beacon hits, forced triggers which are collected at a rate of XX~Hz in
-each DOM. The average value of the beacon baselines are very stable, with an average stability of
-XX counts year to year. 
-%figures go here: average beacon waveform, stability, sample values
+The baseline is set to about 10\% of the maximum value of the
+digitizer counts in
+order to capture signals that go below the baseline. Since 2012, the baseline value is set by the DAQ configuration in order to ensure
+stability. The baseline value differs for each digitizer channel in
+each DOM, ranging from 112 to 161 counts in the fACD and 109 to 172
+counts in the ATWD. The baselines for each digitizer channel in each DOM are monitored with
+beacon hits, forced triggers which are collected at a rate of 1.2~Hz
+per DOM
+in in-ice DOMs and 4.8~Hz in IceTop DOMs. The average value of the
+beacon baselines are very stable, with shifts of no more than
+0.2~counts year to year, which corresponds to a stability of 0.05~PE
+in the single photoelectron charge peak. 
+%igures go here: average beacon waveform, stability, sample values
 %for beacon baselines
 The baselines are sensitive to radio frequency interference (RFI). In
 2009, RF signals from a radar transmitter broadcasting at 46.3~MHz

--- a/i3iosart.bib
+++ b/i3iosart.bib
@@ -126,6 +126,23 @@
   Publisher                = {Elsevier}
 }
 
+@article{ICECUBE:DOMEFF,
+      author         = "Tosi, Delia and Wendt, Christopher",
+      title          = "{Calibrating photon detection efficiency in IceCube}",
+      booktitle      = "{Proceedings, 3rd International Conference on Technology
+                        and Instrumentation in Particle Physics (TIPP 2014)}",
+      collaboration  = "IceCube",
+      journal        = "PoS",
+      volume         = "TIPP2014",
+      year           = "2014",
+      pages          = "157",
+      eprint         = "1502.03102",
+      archivePrefix  = "arXiv",
+      primaryClass   = "physics.ins-det",
+      SLACcitation   = "%%CITATION = ARXIV:1502.03102;%%"
+}
+
+
 @Article{ICECUBE:DAQ,
   Title                    = {{The IceCube data acquisition system: Signal capture, digitization, and timestamping}},
   Author                   = {{Abbasi et al.}},


### PR DESCRIPTION
Added section on DOM efficiency measurements (including new reference to Delia and Chris' TIPP proceedings in the .bib file) and numbers for baseline stability.
